### PR TITLE
Add experiment directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,18 @@ singularity exec --nv \
 ```bash
 zip -r archive.zip . -x '*.sif' '*.pt'
 ```
+
+## Running Experiments
+
+Wisteria 環境ではジョブスクリプトを `pjsub` で投入します。`EXP`
+変数に実験名を設定しておくと、`runs/EXP` 以下に学習ログと評価
+結果が保存されます。
+
+```bash
+# 学習
+export EXP=my_exp
+pjsub experiments/wisteria/run_gpu_ddp.sh
+
+# 評価 (同じ EXP を指定)
+pjsub experiments/wisteria/run_gpu_eval.sh
+```

--- a/experiments/wisteria/run_gpu_ddp.sh
+++ b/experiments/wisteria/run_gpu_ddp.sh
@@ -16,9 +16,11 @@ IMG=$CODE/images/gvae_cuda.sif
 
 DATA=$ROOT/datasets
 RUNS=$ROOT/runs
+EXP=${EXP:-ddp_exp}
+EXP_DIR=$RUNS/$EXP
 WANDB=$ROOT/wandb
 
-mkdir -p "$DATA" "$RUNS" "$WANDB"
+mkdir -p "$DATA" "$EXP_DIR" "$WANDB"
 
 export MASTER_ADDR=127.0.0.1
 export MASTER_PORT=29500
@@ -39,5 +41,6 @@ singularity exec --nv \
     torchrun --nproc_per_node 8 \
              --master_addr $MASTER_ADDR --master_port $MASTER_PORT \
              -m gvae.train.train_graphvae_ddp \
-             --config /workspace/graph-vae/experiments/configs/qm9_ddp.yaml
+             --config /workspace/graph-vae/experiments/configs/qm9_ddp.yaml \
+             --log_dir /workspace/runs/'"$EXP"'
   '

--- a/experiments/wisteria/run_gpu_eval.sh
+++ b/experiments/wisteria/run_gpu_eval.sh
@@ -15,10 +15,12 @@ ROOT=/work/01/jh210022o/q25030
 CODE=$ROOT/graph-vae
 IMG=$CODE/images/gvae_cuda.sif     
 DATA=$ROOT/datasets                
-RUNS=$ROOT/runs                    
+RUNS=$ROOT/runs
+EXP=${EXP:-ddp_exp}
+EXP_DIR=$RUNS/$EXP
 WANDB=$ROOT/wandb                  
 
-mkdir -p "$DATA" "$RUNS" "$WANDB"
+mkdir -p "$DATA" "$EXP_DIR" "$WANDB"
 
 singularity exec --nv \
   -B "$CODE":/workspace/graph-vae \
@@ -31,8 +33,6 @@ singularity exec --nv \
     export TORCH_GEOMETRIC_HOME=/dataset
     export WANDB_MODE=offline
 
-    ln -sf /workspace/runs/graphvae_ddp_amp.pt \
-           /workspace/runs/graphvae_stable.pt
 
     export QM9_ROOT=/dataset/QM9
     export PYG_DISABLE_DOWNLOAD=1
@@ -42,5 +42,7 @@ singularity exec --nv \
       ln -sf /dataset/QM9/processed/data_v3.pt \
              /dataset/QM9/processed/data_molecule.pt || true
 
-    python -m gvae.eval.eval_stable
+    python -m gvae.eval.eval_stable \
+           --ckpt /workspace/runs/"$EXP"/graphvae_ddp_amp.pt \
+           --out /workspace/runs/"$EXP"/eval.txt
   '


### PR DESCRIPTION
## Summary
- allow training and evaluation scripts to save into `runs/EXP` when `EXP` is set
- support custom checkpoint path and output file in `eval_stable.py`
- document how to run these scripts
- document pjsub usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c31a04674832c8bb35b5a9c4011e4